### PR TITLE
Do not obsucre original function.

### DIFF
--- a/function_trace/__init__.py
+++ b/function_trace/__init__.py
@@ -29,6 +29,7 @@ with trace_on([Class1, module1, Class2, module2]):
 '''
 
 from contextlib import contextmanager, closing
+from functools import wraps
 from inspect import isclass, ismethod, getmembers
 import threading
 import os
@@ -138,6 +139,7 @@ class PerThreadFileTracer(Tracer):
 
 
 def add_trace(f, tracer, depth=None):
+    @wraps(f)
     def traced_fn(*args, **kwargs):
         return tracer.trace(f, args, kwargs, additional_depth=depth)
     traced_fn.trace = True  # set flag so that we don't add trace more than once

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name="function_trace",
-    version="1.0.2",
+    version="1.0.3",
     packages=find_packages(),
 
     # metadata for upload to PyPI


### PR DESCRIPTION
- Uses `@wraps` to transfer properties from the wrapped function to the wrapper so we can see the function name that failed in wait_for()
